### PR TITLE
Uninitialized constant error fix

### DIFF
--- a/lib/generators/nexmo_initializer/nexmo_initializer_generator.rb
+++ b/lib/generators/nexmo_initializer/nexmo_initializer_generator.rb
@@ -1,5 +1,4 @@
 require 'rails/generators'
-require 'nexmo'
 class NexmoInitializerGenerator < Rails::Generators::Base
     source_root File.expand_path('../templates', __FILE__)
 
@@ -7,6 +6,8 @@ class NexmoInitializerGenerator < Rails::Generators::Base
 
     def create_nexmo_initializer
       initializer "nexmo.rb" do <<~HEREDOC 
+        require 'nexmo'
+        
         ::Nexmo = Nexmo::Client.new do |config|
           config.api_key = ENV['NEXMO_API_KEY'],
           config.api_secret = ENV['NEXMO_API_SECRET'],


### PR DESCRIPTION
Adding the `require nexmo` statement to the initializer itself to address issue #1.