### PR TITLE
added dotenv-rails as a dependency

### DIFF
--- a/nexmo_rails.gemspec
+++ b/nexmo_rails.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('jwt', '~> 2')
   spec.add_dependency('nexmo', '~> 5.5')
+  spec.add_dependency('dotenv-rails')
   spec.add_development_dependency('rspec')
   spec.add_development_dependency('generator_spec')
 


### PR DESCRIPTION
Since this gem requires `dotenv-rails` for environment variable management, in this PR it is added as a dependency. This addresses #2.