### PR TITLE
Add conversation apis to delegators

### DIFF
--- a/lib/nexmo_rails.rb
+++ b/lib/nexmo_rails.rb
@@ -9,9 +9,7 @@ module Nexmo
 
     def_delegators :@client, :sms, :tfa, :calls, :verify,
                    :number_insight, :applications, :numbers,
-                   :secrets, :redact, :signature, :conversations,
-                   :conversation_users, :conversation_members,
-                   :conversation_legs, :conversation_events
+                   :secrets, :redact, :signature, :conversations
 
     def setup
       self.client = ::Nexmo::Client.new do |config|

--- a/lib/nexmo_rails.rb
+++ b/lib/nexmo_rails.rb
@@ -9,7 +9,9 @@ module Nexmo
 
     def_delegators :@client, :sms, :tfa, :calls, :verify,
                    :number_insight, :applications, :numbers,
-                   :secrets, :redact, :signature
+                   :secrets, :redact, :signature, :conversations,
+                   :conversation_users, :conversation_members,
+                   :conversation_legs, :conversation_events
 
     def setup
       self.client = ::Nexmo::Client.new do |config|


### PR DESCRIPTION
The `Conversations` API was recently added to the Ruby library and as a result, we need to update the Rails gem to include those services in `def_delegators`. 