### PR TITLE
Fixed compatibility issue with Ruby client

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 0.3.0
+
+* Fixed compatibility issue with Nexmo Ruby Client library and now passing in a hash to initialize a new instance
+
 # 0.2.0
 
 * Added support for account, alerts, conversions, files and pricing Client methods 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # 0.3.0
 
 * Fixed compatibility issue with Nexmo Ruby Client library and now passing in a hash to initialize a new instance
+<br>
+(NOTE: **This is a breaking change**. Upon upgrading to 0.3.0, it is recommended to rerun the initializer.)
 
 # 0.2.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # 0.3.0
 
 * Fixed compatibility issue with Nexmo Ruby Client library and now passing in a hash to initialize a new instance
+* Renamed `api_signature` to `signature_secret` in `nexmo_initializer_generator.rb` to conform to naming in Nexmo Ruby Client library
 <br>
 (NOTE: **This is a breaking change**. Upon upgrading to 0.3.0, it is recommended to rerun the initializer.)
 

--- a/lib/generators/nexmo_initializer/nexmo_initializer_generator.rb
+++ b/lib/generators/nexmo_initializer/nexmo_initializer_generator.rb
@@ -10,7 +10,7 @@ class NexmoInitializerGenerator < Rails::Generators::Base
         Nexmo.setup do |config|
           config.api_key = ENV['NEXMO_API_KEY'],
           config.api_secret = ENV['NEXMO_API_SECRET'],
-          config.api_signature = ENV['NEXMO_API_SIGNATURE'],
+          config.signature_secret = ENV['NEXMO_API_SIGNATURE'],
           config.application_id = ENV['NEXMO_APPLICATION_ID'],
           config.private_key = ENV['NEXMO_PRIVATE_KEY']
         end

--- a/lib/generators/nexmo_initializer/nexmo_initializer_generator.rb
+++ b/lib/generators/nexmo_initializer/nexmo_initializer_generator.rb
@@ -8,10 +8,10 @@ class NexmoInitializerGenerator < Rails::Generators::Base
     def create_nexmo_initializer
       initializer "nexmo.rb" do <<~HEREDOC
         Nexmo.setup do |config|
-          config.api_key = ENV['NEXMO_API_KEY'],
-          config.api_secret = ENV['NEXMO_API_SECRET'],
-          config.signature_secret = ENV['NEXMO_API_SIGNATURE'],
-          config.application_id = ENV['NEXMO_APPLICATION_ID'],
+          config.api_key = ENV['NEXMO_API_KEY']
+          config.api_secret = ENV['NEXMO_API_SECRET']
+          config.signature_secret = ENV['NEXMO_API_SIGNATURE']
+          config.application_id = ENV['NEXMO_APPLICATION_ID']
           config.private_key = ENV['NEXMO_PRIVATE_KEY']
         end
         HEREDOC

--- a/lib/nexmo_rails.rb
+++ b/lib/nexmo_rails.rb
@@ -12,10 +12,17 @@ module Nexmo
                    :numbers, :number_insight, :pricing, :redact, 
                    :secrets, :sms, :signature, :tfa, :verify
                    
-    def setup
-      self.client = ::Nexmo::Client.new do |config|
-        yield config
-      end
+    def setup(&block)
+      config = OpenStruct.new 
+      config.instance_eval(&block)
+
+      self.client = ::Nexmo::Client.new(
+        api_key: config.api_key,
+        api_secret: config.api_secret,
+        signature_secret: config.signature_secret,
+        application_id: config.application_id,
+        private_key: config.private_key
+      )
     end
   end
 end

--- a/lib/nexmo_rails/version.rb
+++ b/lib/nexmo_rails/version.rb
@@ -1,3 +1,3 @@
 module NexmoRails
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end

--- a/spec/lib/generators/tmp/config/initializers/nexmo.rb
+++ b/spec/lib/generators/tmp/config/initializers/nexmo.rb
@@ -1,7 +1,7 @@
 Nexmo.setup do |config|
   config.api_key = ENV['NEXMO_API_KEY'],
   config.api_secret = ENV['NEXMO_API_SECRET'],
-  config.api_signature = ENV['NEXMO_API_SIGNATURE'],
+  config.signature_secret = ENV['NEXMO_API_SIGNATURE'],
   config.application_id = ENV['NEXMO_APPLICATION_ID'],
   config.private_key = ENV['NEXMO_PRIVATE_KEY']
 end

--- a/spec/lib/generators/tmp/config/initializers/nexmo.rb
+++ b/spec/lib/generators/tmp/config/initializers/nexmo.rb
@@ -1,7 +1,7 @@
 Nexmo.setup do |config|
-  config.api_key = ENV['NEXMO_API_KEY'],
-  config.api_secret = ENV['NEXMO_API_SECRET'],
-  config.signature_secret = ENV['NEXMO_API_SIGNATURE'],
-  config.application_id = ENV['NEXMO_APPLICATION_ID'],
+  config.api_key = ENV['NEXMO_API_KEY']
+  config.api_secret = ENV['NEXMO_API_SECRET']
+  config.signature_secret = ENV['NEXMO_API_SIGNATURE']
+  config.application_id = ENV['NEXMO_APPLICATION_ID']
   config.private_key = ENV['NEXMO_PRIVATE_KEY']
 end

--- a/spec/lib/nexmo_rails_spec.rb
+++ b/spec/lib/nexmo_rails_spec.rb
@@ -6,16 +6,23 @@ describe Nexmo do
 
     before do
       described_class.setup do |config|
-        config.api_key        = 'NEXMO_API_KEY',
-        config.api_secret     = 'NEXMO_API_SECRET',
-        config.api_signature  = 'NEXMO_API_SIGNATURE',
-        config.application_id = 'NEXMO_APPLICATION_ID',
-        config.private_key    = 'NEXMO_PRIVATE_KEY'
+        config.api_key           = 'NEXMO_API_KEY'
+        config.api_secret        = 'NEXMO_API_SECRET'
+        config.signature_secret  = 'NEXMO_API_SIGNATURE'
+        config.application_id    = 'NEXMO_APPLICATION_ID'
+        config.private_key       = 'NEXMO_PRIVATE_KEY'
       end
     end
 
     it 'sets up the client' do
-      expect(described_class.client).to be_an_instance_of(::Nexmo::Client)
-    end
+      client = described_class.client
+
+      expect(client).to be_an_instance_of(::Nexmo::Client)
+      expect(client.api_key).to eq('NEXMO_API_KEY')
+      expect(client.api_secret).to eq('NEXMO_API_SECRET')
+      expect(client.signature_secret).to eq('NEXMO_API_SIGNATURE')
+      expect(client.application_id).to eq('NEXMO_APPLICATION_ID')
+      expect(client.private_key).to eq('NEXMO_PRIVATE_KEY')
+     end
   end
 end


### PR DESCRIPTION
Breaking Change: Initializer now takes in passed in config block and converts it into a hash and uses that to initialize a new instance of the Nexmo client, which is in accordance with the setup in the Ruby client library.