### PR TITLE
Fix initialization bug with private key

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 0.3.1
+
+* Fixed initialization of `private key` to read the file in the path defined in the config
+
 # 0.3.0
 
 * Fixed compatibility issue with Nexmo Ruby Client library and now passing in a hash to initialize a new instance

--- a/lib/nexmo_rails.rb
+++ b/lib/nexmo_rails.rb
@@ -21,7 +21,7 @@ module Nexmo
         api_secret: config.api_secret,
         signature_secret: config.signature_secret,
         application_id: config.application_id,
-        private_key: File.read(config.private_key)
+        private_key: File.exist?(config.private_key) ? File.read(config.private_key) : config.private_key
       )
     end
   end

--- a/lib/nexmo_rails.rb
+++ b/lib/nexmo_rails.rb
@@ -21,7 +21,7 @@ module Nexmo
         api_secret: config.api_secret,
         signature_secret: config.signature_secret,
         application_id: config.application_id,
-        private_key: config.private_key
+        private_key: File.read(config.private_key)
       )
     end
   end

--- a/lib/nexmo_rails/version.rb
+++ b/lib/nexmo_rails/version.rb
@@ -1,3 +1,3 @@
 module NexmoRails
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end


### PR DESCRIPTION
This PR fixes a bug wherein the client was being initialized with the private key equaling the literal string of the file path defined in the config, as opposed to reading the contents of that file path.