### PR TITLE
Add SimpleCov for reporting test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ test/dummy/storage/
 test/dummy/tmp/
 Gemfile.lock
 .DS_Store
+coverage

--- a/lib/nexmo_rails/version.rb
+++ b/lib/nexmo_rails/version.rb
@@ -1,3 +1,5 @@
+# :nocov:
 module NexmoRails
   VERSION = '0.4.1'
 end
+# :nocov:

--- a/nexmo_rails.gemspec
+++ b/nexmo_rails.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency('nexmo', '~> 5.5')
   spec.add_dependency('dotenv-rails')
   spec.add_development_dependency('rspec')
+  spec.add_development_dependency('rails')
   spec.add_development_dependency('generator_spec')
-  spec.add_development_dependency('rails-dummy')
   spec.add_development_dependency('simplecov', '~> 0.16')
 
   spec.metadata = {

--- a/nexmo_rails.gemspec
+++ b/nexmo_rails.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('rspec')
   spec.add_development_dependency('generator_spec')
   spec.add_development_dependency('rails-dummy')
+  spec.add_development_dependency('simplecov', '~> 0.16')
 
   spec.metadata = {
     'homepage' => 'https://github.com/Nexmo/nexmo-rails',

--- a/spec/lib/generators/nexmo_initializer/nexmo_initializer_generator_spec.rb
+++ b/spec/lib/generators/nexmo_initializer/nexmo_initializer_generator_spec.rb
@@ -12,7 +12,7 @@ describe NexmoInitializerGenerator, type: :generator do
   end
 
   describe 'nexmo_initializer_generator' do 
-    it "creates a Nexmo initializer" do
+    it 'creates a Nexmo initializer' do
       assert_file "config/initializers/nexmo.rb"
     end
   end

--- a/spec/lib/generators/nexmo_initializer/nexmo_initializer_generator_spec.rb
+++ b/spec/lib/generators/nexmo_initializer/nexmo_initializer_generator_spec.rb
@@ -11,7 +11,9 @@ describe NexmoInitializerGenerator, type: :generator do
     run_generator
   end
 
-  it "creates a Nexmo initializer" do
-    assert_file "config/initializers/nexmo.rb"
+  describe 'nexmo_initializer_generator' do 
+    it "creates a Nexmo initializer" do
+      assert_file "config/initializers/nexmo.rb"
+    end
   end
 end

--- a/spec/lib/generators/tmp/config/initializers/nexmo.rb
+++ b/spec/lib/generators/tmp/config/initializers/nexmo.rb
@@ -1,7 +1,0 @@
-Nexmo.setup do |config|
-  config.api_key = ENV['NEXMO_API_KEY']
-  config.api_secret = ENV['NEXMO_API_SECRET']
-  config.signature_secret = ENV['NEXMO_API_SIGNATURE']
-  config.application_id = ENV['NEXMO_APPLICATION_ID']
-  config.private_key = ENV['NEXMO_PRIVATE_KEY']
-end

--- a/spec/lib/nexmo_rails/version_spec.rb
+++ b/spec/lib/nexmo_rails/version_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe NexmoRails::VERSION do
+    it 'is a number' do
+        stub_const("NexmoRails::VERSION", 2)
+
+        expect(NexmoRails::VERSION).to eq(2)
+    end
+end

--- a/spec/lib/nexmo_rails/version_spec.rb
+++ b/spec/lib/nexmo_rails/version_spec.rb
@@ -1,9 +1,0 @@
-require 'spec_helper'
-
-describe NexmoRails::VERSION do
-  it 'is a number' do
-    stub_const("NexmoRails::VERSION", 2)
-
-    expect(NexmoRails::VERSION).to eq(2)
-  end
-end

--- a/spec/lib/nexmo_rails/version_spec.rb
+++ b/spec/lib/nexmo_rails/version_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe NexmoRails::VERSION do
-    it 'is a number' do
-        stub_const("NexmoRails::VERSION", 2)
+  it 'is a number' do
+    stub_const("NexmoRails::VERSION", 2)
 
-        expect(NexmoRails::VERSION).to eq(2)
-    end
+    expect(NexmoRails::VERSION).to eq(2)
+  end
 end

--- a/spec/lib/nexmo_rails_spec.rb
+++ b/spec/lib/nexmo_rails_spec.rb
@@ -1,5 +1,5 @@
-require_relative '../../lib/nexmo_rails'
 require 'spec_helper'
+require_relative '../../lib/nexmo_rails'
 
 describe Nexmo do
   describe '.setup' do
@@ -23,6 +23,7 @@ describe Nexmo do
       expect(client.signature_secret).to eq('NEXMO_API_SIGNATURE')
       expect(client.application_id).to eq('NEXMO_APPLICATION_ID')
       expect(client.private_key).to eq('NEXMO_PRIVATE_KEY')
-     end
+    end
   end
 end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,11 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+require 'simplecov'
+SimpleCov.start 'rails' do
+  add_filter "/spec/"
+end
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,7 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require 'simplecov'
 SimpleCov.start 'rails' do
-  add_filter "/spec/"
+  add_filter '/spec/'
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
This PR adds SimpleCov to give us insight into test coverage in the gem. A few changes were required to make it helpful:

* ignore comments were added around the `version.rb` code so as to not include that in the calculation
* `rails-dummy` was removed from the dev dependencies, as it has an old version of Rails included, and the tests were not running properly. `rails` was added as a new dev dependency instead.