### PR TITLE
Bumped nexmo-ruby dependency to v6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,8 @@ dist: xenial
 language: ruby
 cache: bundler
 rvm:
-  - 2.3
-  - 2.4
   - 2.5
   - 2.6
-  - jruby-9.1
   - jruby-9.2
 before_install:
   - gem install rubygems-update -N -v '<3' && update_rubygems

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 0.5.0
+
+* Upgraded `nexmo-ruby` dependency to `6.0.0`. There are backwards incompatible changes in the latest version of `nexmo-ruby`, please see the [changelog](https://github.com/Nexmo/nexmo-ruby/blob/master/CHANGES.md) for details.
+
 # 0.4.2
 
 * Fixed bug when initializing with Credentials and no private key provided

--- a/lib/nexmo_rails.rb
+++ b/lib/nexmo_rails.rb
@@ -8,8 +8,8 @@ module Nexmo
     attr_accessor :client
 
     def_delegators :@client, :account, :alerts, :applications, 
-                   :applications_v2, :calls, :conversations,
-                   :conversions, :files, :messages, :numbers,
+                   :calls, :conversations, :conversions, 
+                   :files, :messages, :numbers,
                    :number_insight, :pricing, :redact, :secrets,
                    :sms, :signature, :tfa, :verify
                    

--- a/lib/nexmo_rails/version.rb
+++ b/lib/nexmo_rails/version.rb
@@ -1,5 +1,5 @@
 # :nocov:
 module NexmoRails
-  VERSION = '0.4.2'
+  VERSION = '0.5.0'
 end
 # :nocov:

--- a/nexmo_rails.gemspec
+++ b/nexmo_rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{lib}/**/*", "LICENSE", "Rakefile", "README.md"]
 
   spec.add_dependency('jwt', '~> 2')
-  spec.add_dependency('nexmo', '~> 5.5')
+  spec.add_dependency('nexmo', '~> 6.0')
   spec.add_dependency('dotenv-rails')
   spec.add_development_dependency('rspec')
   spec.add_development_dependency('rails')

--- a/spec/lib/nexmo_rails_spec.rb
+++ b/spec/lib/nexmo_rails_spec.rb
@@ -15,15 +15,15 @@ describe Nexmo do
       end
     end
 
-    it 'sets up the client' do
+    it 'sets up the config' do
       client = described_class.client
 
       expect(client).to be_an_instance_of(::Nexmo::Client)
-      expect(client.api_key).to eq('NEXMO_API_KEY')
-      expect(client.api_secret).to eq('NEXMO_API_SECRET')
-      expect(client.signature_secret).to eq('NEXMO_API_SIGNATURE')
-      expect(client.application_id).to eq('NEXMO_APPLICATION_ID')
-      expect(client.private_key).to eq('NEXMO_PRIVATE_KEY')
+      expect(client.config.api_key).to eq('NEXMO_API_KEY')
+      expect(client.config.api_secret).to eq('NEXMO_API_SECRET')
+      expect(client.config.signature_secret).to eq('NEXMO_API_SIGNATURE')
+      expect(client.config.application_id).to eq('NEXMO_APPLICATION_ID')
+      expect(client.config.private_key).to eq('NEXMO_PRIVATE_KEY')
     end
   end
 
@@ -43,7 +43,7 @@ describe Nexmo do
     it 'uses file path for private key when it is present' do
       client = described_class.client
 
-      expect(client.private_key).to eq('./private.key')
+      expect(client.config.private_key).to eq('./private.key')
     end
   end
 
@@ -62,7 +62,7 @@ describe Nexmo do
     it 'does not define a private key if one is not given' do
       client = described_class.client
 
-      expect(client.private_key).to be_blank
+      expect(client.config.private_key).to be_blank
     end
   end
 end


### PR DESCRIPTION
Upgraded the `nexmo-ruby` main dependency to v6.0 and adjusted the tests to account for the new `nexmo-ruby` namespacing for API credentials.