### PR TITLE
rename calls to voice in delegators

### DIFF
--- a/lib/nexmo_rails.rb
+++ b/lib/nexmo_rails.rb
@@ -8,7 +8,7 @@ module Nexmo
     attr_accessor :client
 
     def_delegators :@client, :account, :alerts, :applications, 
-                   :calls, :conversations, :conversions, 
+                   :voice, :conversations, :conversions,
                    :files, :messages, :numbers,
                    :number_insight, :pricing, :redact, :secrets,
                    :sms, :signature, :tfa, :verify


### PR DESCRIPTION
Per [the changes](https://github.com/Nexmo/nexmo-ruby/commit/a2ed0b34afc112619788c989d6b6f5d1ec06719e) in v7.0 of the Ruby SDK, the previously named `calls` class is now `voice` and the `def_delegators` in the gem need to be updated to account for it.